### PR TITLE
Copying the event handlers on reconnection

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-websocket",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "homepage": "https://github.com/gdi2290/angular-websocket",
   "authors": [
     "gdi2290 <github@gdi2290.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-websocket",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "angular-websocket.js",
   "description": "WebSocket service for Angular.js",
   "homepage": "https://github.com/gdi2290/angular-websocket",


### PR DESCRIPTION
also maintaining the uri and protocol across reconnects.

The issue is that once you call WebSocket.new() you lose all the event handlers on your socket.
